### PR TITLE
fix occ configreport:generate

### DIFF
--- a/lib/Command/ConfigReport.php
+++ b/lib/Command/ConfigReport.php
@@ -51,7 +51,6 @@ class ConfigReport extends Command {
 			\OC_Util::getEditionString(),
 			\OCP\User::getDisplayName(),
 			\OC::$server->getSystemConfig(),
-			\OC::$server->getOcsClient(),
 			\OC::$server->getAppConfig()
 		);
 


### PR DESCRIPTION
Since an argument in the Configreport DataCollector has been removed, the command was broken, this fixed the command.