### PR TITLE
fixed command registration for 9.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,4 @@
 	</dependencies>
 	<shipped>true</shipped>
 	<default_enable/>
-	<commands>
-		<command>OCA\ConfigReport\Command\ConfigReport</command>
-	</commands>
 </info>

--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -1,0 +1,4 @@
+<?php
+
+/** @var Symfony\Component\Console\Application $application */
+$application->add(new \OCA\ConfigReport\Command\ConfigReport());


### PR DESCRIPTION
Commands have to be registered manually in 9.1, this PR fixed this issue, so the command is actually available for 9.1 now.