### PR TITLE
move user count to dedicated stats section, add group count

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -31,8 +31,8 @@ class Application extends App {
 		$container->registerService('ReportDataCollector', function($c){
 			return new ReportDataCollector(
 				\OC::$server->getIntegrityCodeChecker(),
-				\OC_User::getUsers(),
 				\OC::$server->getUserManager(),
+				\OC::$server->getGroupManager(),
 				\OC_Util::getVersion(),
 				\OC_Util::getVersionString(),
 				\OC_Util::getEditionString(),

--- a/lib/Command/ConfigReport.php
+++ b/lib/Command/ConfigReport.php
@@ -43,8 +43,8 @@ class ConfigReport extends Command {
 	public function run(InputInterface $input, OutputInterface $output) {
 		$this->reportDataCollector = new ReportDataCollector(
 			\OC::$server->getIntegrityCodeChecker(),
-			\OC_User::getUsers(),
 			\OC::$server->getUserManager(),
+			\OC::$server->getGroupManager(),
 			\OC_Util::getVersion(),
 			\OC_Util::getVersionString(),
 			\OC_Util::getEditionString(),

--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -21,6 +21,8 @@ use OC\IntegrityCheck\Checker;
 use OC\SystemConfig;
 use OC\User\Manager;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUser;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -34,14 +36,14 @@ class ReportDataCollector {
 	private $integrityChecker;
 
 	/**
-	 * @var array
-	 */
-	private $users;
-
-	/**
 	 * @var Manager
 	 */
 	private $userManager;
+
+	/**
+	 * @var IGroupManager
+	 */
+	private $groupManager;
 
 	/**
 	 * @var string
@@ -90,8 +92,8 @@ class ReportDataCollector {
 
 	/**
 	 * @param Checker $integrityChecker
-	 * @param array $users
 	 * @param Manager $userManager
+	 * @param IGroupManager $groupManager
 	 * @param array $version
 	 * @param string $versionString
 	 * @param string $editionString
@@ -101,8 +103,8 @@ class ReportDataCollector {
 	 */
 	public function __construct(
 		Checker $integrityChecker,
-		array $users,
 		Manager $userManager,
+		IGroupManager $groupManager,
 		array $version,
 		$versionString,
 		$editionString,
@@ -111,8 +113,8 @@ class ReportDataCollector {
 		IAppConfig $appConfig
 	) {
 		$this->integrityChecker = $integrityChecker;
-		$this->users = $users;
 		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
 		$this->licenseKey = \OCP\IConfig::SENSITIVE_VALUE;
 
 		$this->version = $version;
@@ -160,6 +162,7 @@ class ReportDataCollector {
 
 		$report = [
 			'basic' => $this->getBasicDetailArray(),
+			'stats' => $this->getStatsDetailArray(),
 			'config' => $this->getSystemConfigDetailArray(),
 			'integritychecker' => $this->getIntegrityCheckerDetailArray(),
 			'core' => $this->getCoreConfigArray(),
@@ -185,19 +188,10 @@ class ReportDataCollector {
 	}
 
 	/**
+	 * Basic report data
 	 * @return array
 	 */
 	private function getBasicDetailArray() {
-		// Basic report data
-		// TODO $homecount should be determined by \OC::$server->getUserManager()->search()
-		// and then checking the lastLoginTime of each user object, leaving current impl intact
-		$homeCount = 0;
-		foreach($this->users as $uid) {
-			if($this->userManager->get($uid)) {
-				$homeCount++;
-			}
-		}
-
 		return [
 			'license key' => $this->licenseKey,
 			'date' => date('r'),
@@ -209,8 +203,6 @@ class ReportDataCollector {
 			'server SAPI' => php_sapi_name(),
 			'webserver version' => $_SERVER['SERVER_SOFTWARE'],
 			'hostname' => $_SERVER['HTTP_HOST'],
-			'user count' => count($this->users),
-			'user directories' => $homeCount,
 			'logged-in user' => $this->displayName,
 		];
 	}
@@ -218,6 +210,39 @@ class ReportDataCollector {
 	/**
 	 * @return array
 	 */
+	private function getStatsDetailArray() {
+		$users = [];
+		$this->userManager->callForAllUsers(function(IUser $user) use (&$users) {
+			if (!isset($users[$user->getBackendClassName()])) {
+				$users[$user->getBackendClassName()] = ['count' => 0, 'seen' => 0, 'logged in (30 days)' => 0];
+			}
+			$users[$user->getBackendClassName()]['count']++;
+			if ($user->getLastLogin() > 0) {
+				$users[$user->getBackendClassName()]['seen']++;
+				if ($user->getLastLogin() > strtotime('-30 days')) {
+					$users[$user->getBackendClassName()]['logged in (30 days)']++;
+				}
+			}
+		});
+
+		$groupCount = [];
+		$groups = $this->groupManager->search('');
+		foreach ($groups as $group) {
+			$backendName = get_class($group->getBackend());
+			if (!isset($groupCount[$backendName])) {
+				$groupCount[$backendName] = 0;
+			}
+			$groupCount[$backendName]++;
+		}
+
+		return [
+			'users' => $users,
+			'groups' => $groupCount,
+		];
+	}
+	/**
+	* @return array
+	*/
 	private function getSystemConfigDetailArray() {
 		$keys = $this->systemConfig->getKeys();
 		$result = array();


### PR DESCRIPTION
fixes https://github.com/owncloud/configreport/issues/39
fixes https://github.com/owncloud/configreport/issues/30

related:
https://github.com/owncloud/configreport/issues/11

note:
- basic section no longer has user count.
- stats section contains backend specific user and group stats
```json
{
    "basic": {
        "license key": "***REMOVED SENSITIVE VALUE***",
        "date": "Wed, 01 Nov 2017 11:51:57 +0000",
        "ownCloud version": "10.0.3.0",
        "ownCloud version string": "10.0.3 beta",
        "ownCloud edition": "Enterprise",
        "server OS": "Linux",
        "server OS version": "Linux covu 4.4.0-43-Microsoft #1-Microsoft Wed Dec 31 14:42:53 PST 2014 x86_64",
        "server SAPI": "cli",
        "webserver version": null,
        "hostname": null,
        "logged-in user": false
    },
    "stats": {
        "users": {
            "Database": {
                "count": 2,
                "seen": 1,
                "logged in (30 days)": 1
            },
            "LDAP": {
                "count": 103,
                "seen": 0,
                "logged in (30 days)": 0
            }
        },
        "groups": {
            "OC\\Group\\Database": 1
        }
    },
...
```