### PR TITLE
bootstrap testing in ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,66 @@
+workspace:
+  base: /var/www/owncloud
+  path: apps/configreport
+
+branches: [master, release*]
+
+pipeline:
+  install-server:
+    image: owncloudci/core
+    pull: true
+    version: ${OC_VERSION}
+
+  code-compliance-check:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      # currently fails since we rely on OC_Util
+      # - make test-php-codecheck
+      - make test-php-lint
+
+  unit-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - COVERAGE=${COVERAGE}
+    commands:
+      - make test-php-unit
+
+  codecov:
+    image: plugins/codecov:2
+    secrets: [codecov_token]
+    pull: true
+    paths:
+     - tests/output
+    files:
+     - "*.xml"
+    when:
+      event: [push, pull_request]
+      status:  [ success, failure ]
+      matrix:
+        COVERAGE: true
+
+matrix:
+  include:
+
+    #master
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-master-qa
+
+    # stable10
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+
+    - PHP_VERSION: 7.0
+      OC_VERSION: daily-stable10-qa
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-stable10-qa
+      COVERAGE: true
+
+    - PHP_VERSION: 7.2
+      OC_VERSION: daily-stable10-qa
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+tests/output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+app_name=$(notdir $(CURDIR))
+project_directory=$(CURDIR)/../$(app_name)
+
+occ=$(CURDIR)/../../occ
+
+
+.PHONY: test-php-codecheck
+test-php-codecheck:
+	$(occ) app:check-code $(app_name) -c private -c strong-comparison
+	$(occ) app:check-code $(app_name) -c deprecation
+
+.PHONY: test-php-lint
+test-php-lint:
+	../../lib/composer/bin/parallel-lint . --exclude 3rdparty --exclude build .
+
+
+.PHONY: test-php-unit
+test-php-unit:
+	./tests/run-unit.sh

--- a/tests/run-unit.sh
+++ b/tests/run-unit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+if [[ "$(pwd)" == "$(cd "$(dirname "$0")"; pwd -P)" ]]; then
+  echo "Can only be executed from project root!"
+  exit 1
+fi
+
+declare -x COVERAGE
+[[ -z "${COVERAGE}" ]] && COVERAGE="false"
+
+readonly BASE_DIR="$(pwd)"
+
+main () {
+
+  # go to server root dir
+  core_path="$(dirname "$(dirname "${BASE_DIR}")")"
+  cd "${core_path}"
+
+  #php occ app:enable notifications_mail
+
+  # run unit tests
+  if [[ "${COVERAGE}" == "true" ]]; then
+    phpdbg -d memory_limit=4096M -rr ./lib/composer/bin/phpunit --configuration "${BASE_DIR}/tests/unit/phpunit.xml"
+  else
+    ./lib/composer/bin/phpunit --configuration "${BASE_DIR}/tests/unit/phpunit.xml"
+  fi
+
+}
+
+main

--- a/tests/unit/Controller/ReportControllerTest.php
+++ b/tests/unit/Controller/ReportControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Patrick Jahns <pjahns@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License, version 2,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\ConfigReport\Controller;
+
+use OCA\ConfigReport\Http\ReportResponse;
+use OCA\ConfigReport\ReportDataCollector;
+use OCP\IConfig;
+use OCP\IRequest;
+use Test\TestCase;
+
+
+/**
+ * Class ReportControllerTest
+ *
+ * @package OCA\ConfigReport\Controller
+ */
+class ReportControllerTest extends TestCase {
+
+	/** @var IConfig */
+	private $config;
+	/** @var IRequest */
+	private $request;
+	/** @var ReportController */
+	private $controller;
+    /** @var ReportDataCollector */
+	private $reportDataCollector;
+
+
+	protected function setUp() {
+		parent::setUp();
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->reportDataCollector = $this->getMockBuilder(ReportDataCollector::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->controller = new ReportController(
+			'configreport',
+			$this->request,
+			$this->config,
+			$this->reportDataCollector
+		);
+	}
+
+	public function testGetReport() {
+		$expectedValue = json_encode([]);
+		$this->reportDataCollector->method('getReportJson')->willReturn($expectedValue);
+		$result = $this->controller->getReport();
+		$this->assertInstanceOf(ReportResponse::class, $result);
+	}
+}
+

--- a/tests/unit/Http/ReportResponseTest.php
+++ b/tests/unit/Http/ReportResponseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace OCA\ConfigReport\Http;
+
+use Test\TestCase;
+
+class ReportResponseTest extends TestCase {
+
+
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	public function testRender() {
+		$expectedValue = "{}";
+		$response = new ReportResponse(null, null, $expectedValue);
+		$this->assertEquals($response->render(), $expectedValue);
+	}
+
+}
+

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Patrick Jahns <pjahns@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License, version 2,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+require_once __DIR__.'/../../../../tests/bootstrap.php';
+\OC_App::loadApp('configreport');
+OC_Hook::clear();

--- a/tests/unit/phpunit.xml
+++ b/tests/unit/phpunit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="bootstrap.php"
+		 verbose="true"
+		 timeoutForSmallTests="900"
+		 timeoutForMediumTests="900"
+		 timeoutForLargeTests="900"
+		>
+	<testsuite name='unit'>
+		<directory suffix='.php'>.</directory>
+	</testsuite>
+	<!-- filters for code coverage -->
+	<filter>
+		<whitelist>
+			<directory suffix=".php">../../lib</directory>
+			<exclude>
+				<directory suffix=".php">../../tests</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+	<logging>
+		<!-- and this is where your report will be written -->
+		<log type="coverage-clover" target="../output/clover.xml"/>
+	</logging>
+</phpunit>


### PR DESCRIPTION
closes #8 

Bootstrapping testing - for now just two simple tests that check for minimal behavior.

`ReportDataCollector` seems no fun to test - since most methods are private.
Though the sanitization method would be nice to refactor and test I guess