### PR TITLE
adjust CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,15 @@ pipeline:
       matrix:
         COVERAGE: true
 
+  notify:
+    image: plugins/slack:1
+    pull: true
+    secrets: [ slack_webhook ]
+    channel: builds
+    when:
+      status: [ failure, changed ]
+      event: [ push, tag ]
+
 matrix:
   include:
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,7 @@ pipeline:
     image: owncloudci/core
     pull: true
     version: ${OC_VERSION}
+    exclude: apps/configreport
 
   code-compliance-check:
     image: owncloudci/php:${PHP_VERSION}


### PR DESCRIPTION
`configreport` is included in the nightly tarballs - thus it fails building

`exclude` option in `owncloudci/core` can be used to not have this app present from core tarballs and thus allows for testing 

Additionally, notification was added to the yaml