### PR TITLE
Acceptance Tests Structure and 1st test related CLI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,41 @@ pipeline:
     db_username: autotest
     db_password: owncloud
 
+  install-app:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /var/www/owncloud/
+      - php occ a:l
+      - php occ a:e configreport
+      - php occ a:e testing
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=owncloud
+      - php occ log:manage --level 0
+    when:
+      matrix:
+        NEED_INSTALL_APP: true
+
+  fix-permissions:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - chown www-data /var/www/owncloud -R
+      - chmod +x /var/www/owncloud/tests/acceptance/run.sh
+    when:
+      matrix:
+        NEED_SERVER: true
+
+  owncloud-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+      - tail -f /var/www/owncloud/data/owncloud.log
+    when:
+      matrix:
+        NEED_SERVER: true
+
   code-compliance-check:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -33,6 +68,19 @@ pipeline:
     commands:
       - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
       - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
+
+  api-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - TEST_SERVER_URL=http://owncloud
+      - PLATFORM=Linux
+      - BEHAT_SUITE=${BEHAT_SUITE}
+    commands:
+      - make test-acceptance-api
+    when:
+      matrix:
+        TEST_SUITE: api-acceptance
 
   codecov:
     image: plugins/codecov:2
@@ -100,6 +148,17 @@ services:
       matrix:
         DB_HOST: oci
 
+  owncloud:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/var/www/owncloud/
+    command: [ "/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND" ]
+    when:
+      matrix:
+        NEED_SERVER: true
+
+
 matrix:
   include:
 
@@ -112,12 +171,20 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiConfigReport
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
       DB_HOST: pgsql
       DB_TYPE: pgsql
       DB_NAME: owncloud
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiConfigReport
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
       DB_HOST: mysql
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -149,6 +216,10 @@ matrix:
 
     - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
+      TEST_SUITE: api-acceptance
+      BEHAT_SUITE: apiConfigReport
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
       DB_HOST: mysql
       DB_TYPE: mysql
       DB_NAME: owncloud

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ test-php-style-fix:        ## Run php-cs-fixer and fix code style issues
 test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes
 
+.PHONY: test-acceptance-api
+test-acceptance-api:       ## Run API acceptance tests
+test-acceptance-api: vendor/bin/phpunit
+	pushd ../../tests/acceptance && ./run.sh --config ../../apps/configreport/tests/acceptance/config/behat.yml --type api && popd
+
 ##
 ## Dependency management
 ##--------------------------------------
@@ -83,3 +88,6 @@ vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-
 
 vendor-bin/owncloud-codestyle/composer.lock: vendor-bin/owncloud-codestyle/composer.json
 	@echo owncloud-codestyle composer.lock is not up to date.
+
+vendor/bin/phpunit: composer.lock
+	$(COMPOSER_BIN) install

--- a/tests/acceptance/.gitignore
+++ b/tests/acceptance/.gitignore
@@ -1,0 +1,2 @@
+vendor
+output

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1,0 +1,21 @@
+default:
+  autoload:
+     '': %paths.base%/../features/bootstrap
+  suites:
+    apiConfigReport:
+      paths:
+        - %paths.base%/../features/apiConfigReport
+      contexts:
+        - ConfigReportContext:
+        - OccContext:
+        - FeatureContext: &common_feature_context_params
+            baseUrl:  http://localhost:8080
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            ocPath: apps/testing/api/v1/occ
+
+  extensions:
+      jarnaiz\JUnitFormatter\JUnitFormatterExtension:
+          filename: report.xml
+          outputDir: %paths.base%/../output/

--- a/tests/acceptance/features/apiConfigReport/occConfigReportReturnCode.feature
+++ b/tests/acceptance/features/apiConfigReport/occConfigReportReturnCode.feature
@@ -1,0 +1,9 @@
+@api
+Feature: generate a configreport via occ
+  As an administrator
+  I want to generate a configreport to file a support / help request
+  So that administrator can check the server report 
+
+  Scenario: admins generates a configreport
+    Given the administrator has invoked occ command "configreport:generate"
+    Then the command should have been successful

--- a/tests/acceptance/features/bootstrap/ConfigReportContext.php
+++ b/tests/acceptance/features/bootstrap/ConfigReportContext.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author David Toledo <dtoledo@owncloud.com>
+ * @copyright Copyright (c) 2018 David Toledo dtoledo@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use TestHelpers\AppConfigHelper;
+use TestHelpers\SetupHelper;
+
+require_once 'bootstrap.php';
+
+/**
+ * Context for config report specific steps
+ */
+class ConfigReportContext implements Context {
+
+	/**
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+}

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author David Toledo <dtoledo@owncloud.com>
+ * @copyright Copyright (c) 2018 David Toledo dtoledo@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+require __DIR__ . '/../../../../../../lib/base.php';
+require __DIR__ . '/../../../../../../lib/composer/autoload.php';
+
+$classLoader = new \Composer\Autoload\ClassLoader();
+$classLoader->addPsr4(
+	"", __DIR__ . "/../../../../../../tests/acceptance/features/bootstrap", true
+);
+$classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
+$classLoader->addPsr4(
+	"Page\\", __DIR__ . "/../../../../../../tests/acceptance/features/lib", true
+);
+$classLoader->addPsr4(
+	"TestHelpers\\", __DIR__ . "/../../../../../../tests/TestHelpers", true
+);
+
+$classLoader->register();


### PR DESCRIPTION
Acceptance Tests Structure Test for the 1st item https://github.com/owncloud/configreport/issues/66#issue-356997840
- [x] Run the occ command and check that the return code is 0

**How has it been tested**

Running test in local and passed.

```sudo -u www-data ./run.sh --config ../../apps/configreport/tests/acceptance/config/behat.yml --suite apiConfigReport```


```
  Scenario: admins generates a configreport                                 # /var/www/owncloud/apps/configreport/tests/acceptance/features/apiConfigReport/occConfigReportReturnCode.feature:7
[Thu Oct  4 05:07:39 2018] 127.0.0.1:56588 [200]: /ocs/v2.php/apps/testing/api/v1/occ
[Thu Oct  4 05:07:41 2018] 127.0.0.1:56594 [200]: /ocs/v2.php/apps/testing/api/v1/opcache
    Given the administrator has invoked occ command "configreport:generate" # FeatureContext::invokingTheCommand()
    Then the command should have been successful                            # FeatureContext::theCommandShouldHaveBeenSuccessful()
[Thu Oct  4 05:07:46 2018] 127.0.0.1:56598 [200]: /ocs/v1.php/apps/testing/api/v1/apps
[Thu Oct  4 05:07:47 2018] 127.0.0.1:41260 [200]: /ocs/v1.php/apps/testing/api/v1/apps
[Thu Oct  4 05:07:57 2018] 127.0.0.1:56606 [200]: /ocs/v2.php/cloud/apps?filter=disabled
[Thu Oct  4 05:08:06 2018] 127.0.0.1:56610 [200]: /ocs/v2.php/cloud/apps?filter=enabled

1 scenario (1 passed)
2 steps (2 passed)
1m0.91s (17.76Mb)
```

**Definition of Done**

- [x] acceptance test infrastructure
- [x] ``make test-acceptance-api`` Makefile target
- [x] first few test step definitions and feature file with scenarios that run
- [x] make the scenarios pass

