### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="11" />
+		<owncloud min-version="10.2" max-version="11" />
 	</dependencies>
 	<default_enable/>
 	<commands>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/configreport",
   "config" : {
     "platform": {
-      "php": "5.6.37"
+      "php": "7.0.8"
     }
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c0e062bd7c4b2bbb2e5ebd594a4d1e7",
+    "content-hash": "533711ebea3ef735f779ae1d5ea20199",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
