### PR TITLE
Remove branches constraint from .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,6 @@ workspace:
   base: /var/www/owncloud
   path: apps/configreport
 
-branches: [master, release*]
 
 pipeline:
   install-core:


### PR DESCRIPTION
We want to upgrade drone.owncloud.com to Drone 1.x.
The branches settings are not correctly converted automatically and @tboerger and I discussed multiple options how to deal with it:
1. "Fix" the conversion tool
   Cumbersome and there's no perfect solution that would satisfy all users of drone.
2. Port all repos to the new drone 1.x config, possibly using jsonnet
   A lot of work if not done completely naively, high chance of breaking things.
3. Simply remove the condition (what this PR does)
   Fairly easy with only one downside: duplicated builds:
   If a PR is sent from a branch in this repository, we see duplicated builds for the branch AND the PR.
   This will of course be fixed when we move to the newer syntax over time.

A PR is created automatically for all apps bundled with core according to @tboerger and @PVince81.
If this repository does not need a PR for master or an additional PR for a separate branch, let me know in the discussion.

/cc @xoxys