### PR TITLE
drone notify on failure

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -920,6 +920,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1590,6 +1590,9 @@ trigger:
   ref:
   - refs/tags/**
   - refs/heads/master
+  status:
+  - success
+  - failure
 
 depends_on:
 - phpunit-php7.0-sqlite


### PR DESCRIPTION
Like https://github.com/owncloud/activity/pull/794

If a nightly build has failure, then nothing is being reported in rocketchat, because the pipelines stop once there is a failure. So the notify pipeline is never executed.

Adjust so that the notify pipeline will execute on both success and failure.