### PR TITLE
Adjust tests

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1209,7 +1209,7 @@ def installTestrunner(phpVersion, useBundledApp):
 			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
 		] if not useBundledApp else []) + [
 			'cd /var/www/owncloud/testrunner',
-			'make install-composer-deps vendor-bin-deps'
+			'make install-composer-deps'
 		]
 	}]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -795,7 +795,7 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/configreport /var/www/owncloud/server/apps/
   - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
+  - make install-composer-deps
 
 - name: setup-server-configreport
   pull: always
@@ -902,7 +902,7 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/configreport /var/www/owncloud/server/apps/
   - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
+  - make install-composer-deps
 
 - name: setup-server-configreport
   pull: always
@@ -1008,7 +1008,7 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/configreport /var/www/owncloud/server/apps/
   - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
+  - make install-composer-deps
 
 - name: setup-server-configreport
   pull: always
@@ -1115,7 +1115,7 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/configreport /var/www/owncloud/server/apps/
   - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
+  - make install-composer-deps
 
 - name: setup-server-configreport
   pull: always
@@ -1222,7 +1222,7 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/configreport /var/www/owncloud/server/apps/
   - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
+  - make install-composer-deps
 
 - name: setup-server-configreport
   pull: always
@@ -1328,7 +1328,7 @@ steps:
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/configreport /var/www/owncloud/server/apps/
   - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
+  - make install-composer-deps
 
 - name: setup-server-configreport
   pull: always

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="tests/unit/bootstrap.php"
 		 verbose="true"
-		 strict="true"
+		 beStrictAboutOutputDuringTests="true"
 		 failOnRisky="true"
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,9 +8,11 @@
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 >
-	<testsuite name='unit'>
-		<directory suffix='Test.php'>./tests/unit</directory>
-	</testsuite>
+	<testsuites>
+		<testsuite name='unit'>
+			<directory suffix='Test.php'>./tests/unit</directory>
+		</testsuite>
+	</testsuites>
 	<!-- filters for code coverage -->
 	<filter>
 		<whitelist>

--- a/tests/unit/Controller/ReportControllerTest.php
+++ b/tests/unit/Controller/ReportControllerTest.php
@@ -43,7 +43,7 @@ class ReportControllerTest extends TestCase {
 	/** @var ReportDataCollector */
 	private $reportDataCollector;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()

--- a/tests/unit/Http/ReportResponseTest.php
+++ b/tests/unit/Http/ReportResponseTest.php
@@ -5,7 +5,7 @@ namespace OCA\ConfigReport\Http;
 use Test\TestCase;
 
 class ReportResponseTest extends TestCase {
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 	}
 

--- a/tests/unit/ReportDataCollectorTest.php
+++ b/tests/unit/ReportDataCollectorTest.php
@@ -58,7 +58,7 @@ class ReportDataCollectorTest extends TestCase {
 	/** @var ReportDataCollector */
 	private $reportDataCollector;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->integrityChecker = $this->createMock(Checker::class);
@@ -76,7 +76,7 @@ class ReportDataCollectorTest extends TestCase {
 				$this->connection, $this->globalStoragesService);
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$this->restoreService('IntegrityCodeChecker');
 		parent::tearDown();
 	}

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.0.8"
+            "php": "7.1"
         }
     },
     "require": {
@@ -12,6 +12,8 @@
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
-        "symfony/translation": "^3.4"
+        "symfony/translation": "^3.4",
+        "guzzlehttp/guzzle": "^5.3",
+        "phpunit/phpunit": "^7.5"
     }
 }


### PR DESCRIPTION
1) phpunit is reporting "The attribute 'strict' is not allowed". That was a very old option in phpunit. The only "matching" thing for that now is `beStrictAboutOutputDuringTests`, so specify that in `phpunit.xml`
2) In core the unit test infrastructure has been changed to move forward to the newer declarations of the `setUp` and `tearDown` classes with return type `void`. The app unit tests inherit from some core classes, so we have to make the matching changes here in the app. This will future-proof the tests ready for phpunit v8...
3) In the acceptance tests we use `guzzle` and `phpunit` `Assert`. At the moment we "somewhat by accident" get them "for free" in core. (see https://github.com/owncloud/core/issues/36514 ) Install them with `behat` in `vendor-bin/behat` so that we have them "locally" when running acceptance tests. Then we will be able to remove that from core when we like.
4) In `phpunit.xml` put the `testsuite` section inside a `testsuites` section. That is more future-proof - if you more than 1 `testsuite` then you have to have a `testsuites` section anyway.
5) There is no need to install `vendor-bin-deps` in core of the testrunner. That is just a time-waste.
