### PR TITLE
Enable phpstan and adjust code

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -19,6 +19,8 @@ config = {
 		},
 	},
 
+	'phpstan': True,
+
 	'phpunit': {
 		'allDatabases' : {
 			'phpVersions': [

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,7 +23,7 @@ namespace OCA\ConfigReport\AppInfo;
 
 use OCP\AppFramework\App;
 
-$application = new Application('configreport');
+$application = new Application();
 
 $application->registerRoutes(
 	$this,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,10 +17,9 @@ class Application extends App {
 	/**
 	 * Application constructor.
 	 *
-	 * @param string $appName
 	 * @param array $urlParams
 	 */
-	public function __construct($appName, array $urlParams = []) {
+	public function __construct(array $urlParams = []) {
 		parent::__construct('configreport', $urlParams);
 		$this->registerServices();
 	}

--- a/lib/Command/ConfigReport.php
+++ b/lib/Command/ConfigReport.php
@@ -68,5 +68,6 @@ class ConfigReport extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$report = $this->reportDataCollector->getReportJson();
 		$output->writeln($report);
+		return 0;
 	}
 }

--- a/lib/Http/ReportResponse.php
+++ b/lib/Http/ReportResponse.php
@@ -28,7 +28,7 @@ use OCP\AppFramework\Http\DownloadResponse;
 class ReportResponse extends DownloadResponse {
 
 	/**
-	 * @var array $data
+	 * @var string $data
 	 */
 	private $data;
 

--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -79,7 +79,7 @@ class ReportDataCollector {
 	private $systemConfig;
 
 	/**
-	 * @var array
+	 * @var object
 	 */
 	private $appConfigData;
 
@@ -142,7 +142,8 @@ class ReportDataCollector {
 		$this->globalStoragesService = $globalStoragesService;
 
 		$event = new GenericEvent();
-		$this->appConfigData = \OC::$server->getEventDispatcher()->dispatch('OCA\ConfigReport::loadData', $event);
+		/* @phpstan-ignore-next-line */
+		$this->appConfigData = \OC::$server->getEventDispatcher()->dispatch($event, 'OCA\ConfigReport::loadData');
 	}
 
 	/**
@@ -355,6 +356,7 @@ class ReportDataCollector {
 	private function getOcMigrationArray() {
 		//Get data from oc_migrations table
 		$queryBuilder = $this->connection->getQueryBuilder();
+		/* @phpstan-ignore-next-line */
 		$results = $queryBuilder
 			->select('app', 'version')
 			->from('migrations')
@@ -370,6 +372,7 @@ class ReportDataCollector {
 	private function getOCTablesArray() {
 		$ocTables = [];
 		//Get tables structure/description/schema from owncloud db
+		/* @phpstan-ignore-next-line */
 		$schemaManager = $this->connection->getSchemaManager();
 		$tableNames = $schemaManager->listTableNames();
 		foreach ($tableNames as $tableName) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+  inferPrivatePropertyTypeFromConstructor: true
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
+  excludes_analyse:
+    - %currentWorkingDirectory%/appinfo/routes.php
+  ignoreErrors:

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpstan/phpstan": "^0.12"
+    }
+}


### PR DESCRIPTION
While adjusting `phpstan.neon` in other apps, I noticed that it was missing here.
It turned out to be easy enough to enable it. There are only minor code and PHPdoc changes needed.