### PR TITLE
Suppress PhanDeprecatedFunction for doctrine/dbal changes

### DIFF
--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -356,7 +356,7 @@ class ReportDataCollector {
 	private function getOcMigrationArray() {
 		//Get data from oc_migrations table
 		$queryBuilder = $this->connection->getQueryBuilder();
-		/* @phpstan-ignore-next-line */
+		/* @phpstan-ignore-next-line @phan-suppress-next-line PhanDeprecatedFunction */
 		$results = $queryBuilder
 			->select('app', 'version')
 			->from('migrations')


### PR DESCRIPTION
`doctrine/dbal` was updated yesterday in core https://github.com/owncloud/core/pull/38647

Some methods have been deprecated, and `phan` reports those and fails the CI.

Suppress the deprecation warnings for now.

I raised issue #144 to actually adjust the code "some time".