### PR TITLE
[tests-only] [full-ci] Remove npm checks from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,7 @@
 SHELL := /bin/bash
 
 COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
-
 NPM := $(shell command -v npm 2> /dev/null)
-ifndef NPM
-    $(error npm is not available on your system, please install npm)
-endif
-
 NODE_PREFIX=$(shell pwd)
 BOWER=$(NODE_PREFIX)/node_modules/bower/bin/bower
 JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc


### PR DESCRIPTION
The `owncloudci/php` image no longer has nodejs, npm or yarn. It runs PHP tests fine, and we should not complain that `npm` is missing.

Remove the annoying checks from `Makefile`