### PR TITLE
[tests-only] Run acceptance tests against latest core release in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -44,9 +44,6 @@ config = {
                 "postgres:9.4",
                 "oracle",
             ],
-            "servers": [
-                "daily-master-qa",
-            ],
         },
     },
 }


### PR DESCRIPTION
Fixes #148 

Run the acceptance tests against the default set of oC10 core versions (which is "latest" and "daily-master-qa")