### PR TITLE
[Tests-Only] enforce strict type checking in acceptace tests code

### DIFF
--- a/tests/acceptance/features/bootstrap/ConfigReportContext.php
+++ b/tests/acceptance/features/bootstrap/ConfigReportContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *


### PR DESCRIPTION
Related https://github.com/owncloud/QA/issues/694
- add strict type checking on acceptace test code

**note** this PR was generated by a automated script