### PR TITLE
Elastic search credentials are obscured.

### DIFF
--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -336,6 +336,9 @@ class ReportDataCollector {
 			if (\stripos($key, 'password') !== false) {
 				$values[$key] = \OCP\IConfig::SENSITIVE_VALUE;
 			}
+			if ($key === 'server_user') {
+				$values[$key] = \OCP\IConfig::SENSITIVE_VALUE;
+			}
 		}
 		return $values;
 	}


### PR DESCRIPTION
Elastic search credentials are obscured.
Issue: https://github.com/owncloud/configreport/issues/167