### PR TITLE
Hide mount passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] 
 
--
+### Changed
+
+- Hide passwords from the config report [#183](https://github.com/owncloud/configreport/pull/183)
 
 ## [0.2.1] - 2022-04-07
 

--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -474,7 +474,7 @@ class ReportDataCollector {
 
 		// Get the phpinfo, parse it, and record it (parts from http://www.php.net/manual/en/function.phpinfo.php#87463)
 		\ob_start();
-		\phpinfo(-1);
+		\phpinfo(INFO_ALL & ~INFO_ENVIRONMENT);
 
 		$phpinfo = \preg_replace(
 			['#^.*<body>(.*)</body>.*$#ms', '#<h2>PHP License</h2>.*$#ms',

--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -237,9 +237,7 @@ class ReportDataCollector {
 			}
 
 			$configuration = $mount->getBackendOptions();
-			if (isset($configuration['password'])) {
-				$configuration['password'] = \OCP\IConfig::SENSITIVE_VALUE;
-			}
+			$this->hideMountPasswords($mount, $configuration);
 			$mountsArray[] = [
 				'id' => $mount->getId(),
 				'mount_point' => $mount->getMountPoint(),
@@ -253,6 +251,28 @@ class ReportDataCollector {
 			];
 		}
 		return $mountsArray;
+	}
+
+	private function hideMountPasswords(IStorageConfig $mount, array &$configArray) {
+		$backend = $mount->getBackend();
+		$auth = $mount->getAuthMechanism();
+
+		$backendParameters = $backend->getParameters();
+		$authParameters = $auth->getParameters();
+
+		foreach ($configArray as $key => $value) {
+			if (
+				(
+					isset($backendParameters[$key]) &&
+					$backendParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD
+				) || (
+					isset($authParameters[$key]) &&
+					$authParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD
+				)
+			) {
+				$configArray[$key] = \OCP\IConfig::SENSITIVE_VALUE;
+			}
+		}
 	}
 
 	/**

--- a/tests/unit/ReportDataCollectorTest.php
+++ b/tests/unit/ReportDataCollectorTest.php
@@ -29,6 +29,7 @@ use OC\User\Manager;
 use OCA\ConfigReport\ReportDataCollector;
 use OCP\Files\External\Auth\AuthMechanism;
 use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\DefinitionParameter;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -685,16 +686,21 @@ class ReportDataCollectorTest extends TestCase {
 			'host' => 'localhost',
 			'root' => '/test',
 			'user' => 'foo',
-			'password' => 'hello'
+			'password' => 'helloo'
 		]);
 		$sftpStorageConfig->setApplicableUsers(['foo', 'bar']);
 		$sftpStorageConfig->setMountPoint('/MySFTP1');
 
 		$authMechanism = $this->getAuthMechMock();
 		$sftpStorageConfig->setAuthMechanism($authMechanism);
+
+		$definitionParameter = $this->createMock(DefinitionParameter::class);
+		$definitionParameter->method('getName')->willReturn('password');
+		$definitionParameter->method('getType')->willReturn(DefinitionParameter::VALUE_PASSWORD);
 		$backend = $this->createMock(Backend::class);
 		$backend->method('getText')
 			->willReturn('\OCA\Files_External\Lib\Storage\SFTP');
+		$backend->method('getParameters')->willReturn(['password' => $definitionParameter]);
 		$sftpStorageConfig->setBackend($backend);
 
 		$owncloudStorageConfig->setBackendOptions([
@@ -702,27 +708,37 @@ class ReportDataCollectorTest extends TestCase {
 			'root' => '',
 			'secure' => false,
 			'user' => 'foo',
-			'password' => 'hello',
+			'password' => 'heello',
 		]);
 		$owncloudStorageConfig->setMountPoint('/ownCloud');
 		$owncloudStorageConfig->setApplicableUsers(['']);
 		$owncloudStorageConfig->setAuthMechanism($authMechanism);
+
+		$definitionParameter = $this->createMock(DefinitionParameter::class);
+		$definitionParameter->method('getName')->willReturn('password');
+		$definitionParameter->method('getType')->willReturn(DefinitionParameter::VALUE_PASSWORD);
 		$backendOc = $this->createMock(Backend::class);
 		$backendOc->method('getText')
 			->willReturn('\OCA\Files_External\Lib\Storage\OwnCloud');
+		$backendOc->method('getParameters')->willReturn(['password' => $definitionParameter]);
 		$owncloudStorageConfig->setBackend($backendOc);
 
 		$personalStorageConfig->setBackendOptions([
 			'host' => 'localhost',
 			'root' => '/personal',
 			'user' => 'foobar',
-			'password' => 'hello'
+			'password' => 'hhello'
 		]);
 		$personalStorageConfig->setApplicableUsers([]);
 		$personalStorageConfig->setMountPoint('/MyPersonalSFTPMount');
 
 		$personalStorageConfig->setAuthMechanism($authMechanism);
 		$personalStorageConfig->setType(2);
+
+		$definitionParameter = $this->createMock(DefinitionParameter::class);
+		$definitionParameter->method('getName')->willReturn('password');
+		$definitionParameter->method('getType')->willReturn(DefinitionParameter::VALUE_PASSWORD);
+		$backend->method('getParameters')->willReturn(['password' => $definitionParameter]);
 		$backend = $this->createMock(Backend::class);
 		$backend->method('getText')
 			->willReturn('\OCA\Files_External\Lib\Storage\SFTP');
@@ -732,16 +748,21 @@ class ReportDataCollectorTest extends TestCase {
 			'host' => 'localhost',
 			'root' => '/personal2',
 			'user' => 'foobar',
-			'password' => 'hello'
+			'password' => 'hello!'
 		]);
 		$personalStorageConfig1->setApplicableUsers(['foo', 'bar']);
 		$personalStorageConfig1->setMountPoint('/MyPersonalOcMount');
 
 		$personalStorageConfig1->setAuthMechanism($authMechanism);
 		$personalStorageConfig1->setType(2);
+
+		$definitionParameter = $this->createMock(DefinitionParameter::class);
+		$definitionParameter->method('getName')->willReturn('password');
+		$definitionParameter->method('getType')->willReturn(DefinitionParameter::VALUE_PASSWORD);
 		$backendOc = $this->createMock(Backend::class);
 		$backendOc->method('getText')
 			->willReturn('\OCA\Files_External\Lib\Storage\OwnCloud');
+		$backendOc->method('getParameters')->willReturn(['password' => $definitionParameter]);
 		$personalStorageConfig1->setBackend($backendOc);
 
 		$this->globalStoragesService->method('getStorageForAllUsers')


### PR DESCRIPTION
Hide mount keys if they're considered passwords. The code is mostly copied from core in order to follow the same approach of detecting the password.

Related to https://github.com/owncloud/enterprise/issues/5507