### PR TITLE
[tests-only][full-ci]Add creation time array in oc_account 

### DIFF
--- a/tests/unit/ReportDataCollectorTest.php
+++ b/tests/unit/ReportDataCollectorTest.php
@@ -193,6 +193,12 @@ class ReportDataCollectorTest extends TestCase {
 							'null' => false,
 							'default' => '0',
 							'autoIncrement' => false
+						]],
+						['creation_time' => [
+							'type' => 'integer',
+							'null' => false,
+							'default' => '0',
+							'autoIncrement' => false
 						]]
 					],
 					'index' => [
@@ -319,6 +325,12 @@ class ReportDataCollectorTest extends TestCase {
 						]],
 						['state' => [
 							'type' => 'smallint',
+							'null' => false,
+							'default' => '0',
+							'autoIncrement' => false
+						]],
+						['creation_time' => [
+							'type' => 'integer',
 							'null' => false,
 							'default' => '0',
 							'autoIncrement' => false
@@ -451,6 +463,12 @@ class ReportDataCollectorTest extends TestCase {
 							'null' => false,
 							'default' => '0',
 							'autoIncrement' => false
+						]],
+						['creation_time' => [
+							'type' => 'integer',
+							'null' => false,
+							'default' => '0',
+							'autoIncrement' => false
 						]]
 					],
 					'index' => [
@@ -577,6 +595,12 @@ class ReportDataCollectorTest extends TestCase {
 						]],
 						['state' => [
 							'type' => 'smallint',
+							'null' => false,
+							'default' => '0',
+							'autoIncrement' => false
+						]],
+						['creation_time' => [
+							'type' => 'integer',
 							'null' => false,
 							'default' => '0',
 							'autoIncrement' => false


### PR DESCRIPTION
### Description 
This PR fixes nightly failures related to PHP unit tests regarding 
`OCA\ConfigReport\Tests\ReportDataCollectorTest::testGetOCTablesArray`

### Related issue
- [Unit test failing at nightly](https://github.com/owncloud/configreport/issues/184)
- Partially (https://github.com/owncloud/files_primary_s3/issues/650)