### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/ConfigReport.php
+++ b/lib/Command/ConfigReport.php
@@ -66,7 +66,7 @@ class ConfigReport extends Command {
 			->setDescription('generates a configreport');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$report = $this->reportDataCollector->getReportJson();
 		$output->writeln($report);
 		return 0;


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630