### PR TITLE
feat: add daily transmission of config report to ownCloud/kiteworks f…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 
 app_name=$(notdir $(CURDIR))
 doc_files=README.md CHANGELOG.md LICENSE
-src_dirs=appinfo js lib templates
+src_dirs=appinfo js lib templates vendor
 all_src=$(src_dirs) $(doc_files)
 build_dir=$(CURDIR)/build
 dist_dir=$(build_dir)/dist

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<description>Generate a Config Report</description>
 	<summary>Generate a Config Report</summary>
 	<author>owncloud.org</author>
-	<version>0.2.2</version>
+	<version>0.3.0</version>
 	<default_enable/>
 	<types>
 		<filesystem/>
@@ -18,10 +18,14 @@
 	<default_enable/>
 	<commands>
 		<command>OCA\ConfigReport\Command\ConfigReport</command>
+		<command>OCA\ConfigReport\Command\SendTelemetry</command>
 	</commands>
 	<settings>
 		<admin>OCA\ConfigReport\AdminPanel</admin>
 	</settings>
+	<background-jobs>
+		<job>OCA\ConfigReport\Telemetry\BackgroundJob</job>
+	</background-jobs>
 	<category>tools</category>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/next/admin_manual/troubleshooting/providing_logs_and_config_files.html#generate-a-config-report</admin>

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     }
   },
   "require": {
+    "ramsey/uuid": "^4.2"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,481 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1e51a2ac3c1dcb9c65e0d8936ab24c9",
-    "packages": [],
+    "content-hash": "1422accf76f823829e319fe618a450f8",
+    "packages": [
+        {
+            "name": "brick/math",
+            "version": "0.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/ca57d18f028f84f777b2168cd1911b0dee2343ae",
+                "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.0",
+                "vimeo/psalm": "4.9.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "brick",
+                "math"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/brick/math",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-15T20:50:18+00:00"
+        },
+        {
+            "name": "ramsey/collection",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "cccc74ee5e328031b15640b51056ee8d3bb66c0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/cccc74ee5e328031b15640b51056ee8d3bb66c0a",
+                "reference": "cccc74ee5e328031b15640b51056ee8d3bb66c0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "symfony/polyfill-php81": "^1.23"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "ergebnis/composer-normalize": "^2.6",
+                "fakerphp/faker": "^1.5",
+                "hamcrest/hamcrest-php": "^2",
+                "jangregor/phpstan-prophecy": "^0.8",
+                "mockery/mockery": "^1.3",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1",
+                "phpstan/phpstan": "^0.12.32",
+                "phpstan/phpstan-mockery": "^0.12.5",
+                "phpstan/phpstan-phpunit": "^0.12.11",
+                "phpunit/phpunit": "^8.5 || ^9",
+                "psy/psysh": "^0.10.4",
+                "slevomat/coding-standard": "^6.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP library for representing and manipulating collections.",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/collection/issues",
+                "source": "https://github.com/ramsey/collection/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/collection",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-10T03:01:02+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
+                "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8 || ^0.9",
+                "ext-json": "*",
+                "php": "^7.2 || ^8.0",
+                "ramsey/collection": "^1.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-php80": "^1.14"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.10",
+                "captainhook/plugin-composer": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "doctrine/annotations": "^1.8",
+                "ergebnis/composer-normalize": "^2.15",
+                "mockery/mockery": "^1.3",
+                "moontoast/math": "^1.1",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock": "^2.2",
+                "php-mock/php-mock-mockery": "^1.3",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpbench/phpbench": "^1.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-mockery": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^8.5 || ^9",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.9"
+            },
+            "suggest": {
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-ctype": "Enables faster processing of character classification using ctype functions.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                },
+                "captainhook": {
+                    "force-install": true
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "source": "https://github.com/ramsey/uuid/tree/4.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-25T23:10:38+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -75,5 +548,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,22 +28,7 @@ class Application extends App {
 		$container = $this->getContainer();
 
 		$container->registerService('ReportDataCollector', function ($c) {
-			return new ReportDataCollector(
-				\OC::$server->getIntegrityCodeChecker(),
-				\OC::$server->getUserManager(),
-				new UserTypeHelper(),
-				\OC::$server->getGroupManager(),
-				\OC_Util::getVersion(),
-				\OC_Util::getVersionString(),
-				\OC_Util::getEditionString(),
-				/* @phan-suppress-next-line PhanDeprecatedFunction */
-				\OCP\User::getDisplayName(),
-				/* @phan-suppress-next-line PhanAccessMethodInternal */
-				\OC::$server->getSystemConfig(),
-				\OC::$server->getAppConfig(),
-				\OC::$server->getDatabaseConnection(),
-				\OC::$server->getGlobalStoragesService()
-			);
+			return self::getCollector();
 		});
 
 		$container->registerService('ReportController', function (IAppContainer $c) {
@@ -55,5 +40,24 @@ class Application extends App {
 				$c->query('ReportDataCollector')
 			);
 		});
+	}
+
+	public static function getCollector(): ReportDataCollector {
+		return new ReportDataCollector(
+			\OC::$server->getIntegrityCodeChecker(),
+			\OC::$server->getUserManager(),
+			new UserTypeHelper(),
+			\OC::$server->getGroupManager(),
+			\OC_Util::getVersion(),
+			\OC_Util::getVersionString(),
+			\OC_Util::getEditionString(),
+			/* @phan-suppress-next-line PhanDeprecatedFunction */
+			\OCP\User::getDisplayName(),
+			/* @phan-suppress-next-line PhanAccessMethodInternal */
+			\OC::$server->getSystemConfig(),
+			\OC::$server->getAppConfig(),
+			\OC::$server->getDatabaseConnection(),
+			\OC::$server->getGlobalStoragesService()
+		);
 	}
 }

--- a/lib/Command/SendTelemetry.php
+++ b/lib/Command/SendTelemetry.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright Copyright (c) 2024, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace OCA\ConfigReport\Command;
+
+use OCA\ConfigReport\AppInfo\Application;
+use OCA\ConfigReport\Telemetry\Monitor;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SendTelemetry extends Command {
+	protected function configure() {
+		$this
+			->setName('configreport:send-telemetry')
+			->setDescription('send telemetry to backend');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$monitor = new Monitor(
+			\OC::$server->getConfig(),
+			\OC::$server->getLogger(),
+			\OC::$server->getHTTPClientService(),
+			Application::getCollector()
+		);
+
+		$monitor->sendTelemetry();
+		return 0;
+	}
+}

--- a/lib/PHPInfo.php
+++ b/lib/PHPInfo.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 namespace OCA\ConfigReport;
 

--- a/lib/ReportDataCollector.php
+++ b/lib/ReportDataCollector.php
@@ -188,6 +188,35 @@ class ReportDataCollector {
 		return $report;
 	}
 
+	public function getTelemetryReport(string $licenseKey): array {
+		return [
+			'basic' => $this->getBasicDetailArray($licenseKey),
+			'stats' => $this->getStatsDetailArray(),
+			'config' => $this->getSystemConfigDetailArray(),
+			'mounts' => $this->getMountsSimplified(),
+			'phpinfo' => $this->getPhpInfoDetailArray()
+		];
+	}
+
+	private function getMountsSimplified(): array {
+		/** @var IStorageConfig[] $mounts */
+		$mounts = $this->globalStoragesService->getStorageForAllUsers();
+
+		$mountsArray = [];
+
+		foreach ($mounts as $mount) {
+			if ($mount->getType() === IStorageConfig::MOUNT_TYPE_PERSONAl) {
+				continue;
+			}
+			$mountsArray[] = [
+				'id' => $mount->getId(),
+				'storage' => $mount->getBackend()->getText(),
+				'type' => $mount->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'Admin' : 'Personal'
+			];
+		}
+		return $mountsArray;
+	}
+
 	private function getMountsArray(): array {
 		/** @var IStorageConfig[] $mounts */
 		$mounts = $this->globalStoragesService->getStorageForAllUsers();

--- a/lib/Telemetry/BackgroundJob.php
+++ b/lib/Telemetry/BackgroundJob.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\ConfigReport\Telemetry;
+
+use OC\BackgroundJob\Job;
+use OCA\ConfigReport\AppInfo\Application;
+
+class BackgroundJob extends Job {
+	protected function run($argument) {
+		$config = \OC::$server->getConfig();
+		$utcNow = new \DateTimeImmutable("now", new \DateTimeZone('UTC'));
+		$scheduler = new Scheduler($config);
+		if (!$scheduler->isDue($utcNow)) {
+			return;
+		}
+		# send telemetry
+		$m = $this->getMonitor();
+		if ($m->sendTelemetry()) {
+			$scheduler->storeNextExecution($utcNow);
+		}
+	}
+
+	private function getMonitor(): Monitor {
+		return new Monitor(
+			\OC::$server->getConfig(),
+			\OC::$server->getLogger(),
+			\OC::$server->getHTTPClientService(),
+			Application::getCollector()
+		);
+	}
+}

--- a/lib/Telemetry/Monitor.php
+++ b/lib/Telemetry/Monitor.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\ConfigReport\Telemetry;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use OC\License\LicenseFetcher;
+use OCA\ConfigReport\ReportDataCollector;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\ILogger;
+use Ramsey\Uuid\Uuid;
+
+class Monitor {
+	/** @var IConfig */
+	private $config;
+	/** @var ILogger */
+	private $logger;
+	/** @var IClientService */
+	private $clientService;
+	/** @var ReportDataCollector */
+	private $collector;
+
+	public function __construct(IConfig $config, ILogger $logger, IClientService $clientService, ReportDataCollector $collector) {
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->clientService = $clientService;
+		$this->collector = $collector;
+	}
+
+	public function sendTelemetry(): bool {
+		# only customer telemetry is sent over
+		$licenseKey = $this->getLicenseKey();
+		if ($licenseKey === "") {
+			return false;
+		}
+
+		# telemetry is an opt-out feature
+		$telemetryOptIn = $this->config->getSystemValue('telemetry.enabled', true);
+		if (!$telemetryOptIn) {
+			return false;
+		}
+
+		$data = $this->collectTelemetryData();
+
+		$client = $this->clientService->newClient();
+		$requestId = Uuid::uuid4()->toString();
+		try {
+			$telemetryUrl = 'https://telemetry.owncloud.com/oc10-telemetry';
+			$client->post($telemetryUrl, [
+				'body' => json_encode($data, JSON_THROW_ON_ERROR),
+				'headers' => [
+					'X-Request-Id' => $requestId,
+				]
+			]);
+			$this->logger->info("Telemetry data submitted to $telemetryUrl with request id: $requestId");
+			return true;
+		} catch (\Exception $e) {
+			$this->logger->logException($e);
+			return false;
+		}
+	}
+
+	private function getLicenseKey(): string {
+		try {
+			$lf = \OC::$server->query(LicenseFetcher::class);
+			if ($lf instanceof LicenseFetcher) {
+				$l = $lf->getOwncloudLicense();
+				if ($l) {
+					return $l->getLicenseString();
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->logException($e);
+		}
+
+		return "";
+	}
+
+	private function collectTelemetryData(): array {
+		$licenseKey = $this->getLicenseKey();
+		$report = $this->collector->getTelemetryReport($licenseKey);
+		$report['id'] = $this->getTelemetryId();
+		return  $report;
+	}
+
+	private function getTelemetryId() {
+		$id = $this->config->getAppValue("configreport", "telemetry.id", null);
+		if ($id === null) {
+			$id = Uuid::uuid4()->toString();
+			$this->config->setAppValue("configreport", "telemetry.id", $id);
+		}
+
+		return $this->config->getAppValue("configreport", "telemetry.id", null);
+	}
+}

--- a/lib/Telemetry/Scheduler.php
+++ b/lib/Telemetry/Scheduler.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\ConfigReport\Telemetry;
+
+use OCP\IConfig;
+
+class Scheduler {
+	/** @var int */
+	public static $randomTest = -1;
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(
+		IConfig $config
+	) {
+		$this->config = $config;
+	}
+
+	public function isDue(\DateTimeImmutable $utcNow): bool {
+		# in qa this needs adjustments
+		$telemetryStartHour = $this->config->getSystemValue('telemetry.startHour', 6);
+		$telemetryEndHour = $this->config->getSystemValue('telemetry.endHour', 12);
+
+		$transmissionStart = $utcNow->setTime($telemetryStartHour, 0);
+		$transmissionEnd = $utcNow->setTime($telemetryEndHour, 0);
+		if ($utcNow < $transmissionStart) {
+			return false;
+		}
+		if ($utcNow > $transmissionEnd) {
+			return false;
+		}
+
+		# only once a day
+		$nextExecution = $this->config->getAppValue("configreport", "telemetry.nextSubmission", null);
+		if ($nextExecution === null) {
+			$max_minutes = ($telemetryEndHour - $telemetryStartHour) * 60;
+			$offset_minutes = $this->random(0, $max_minutes);
+			$interval = \DateInterval::createFromDateString("$offset_minutes minutes");
+			$nextExecution = $transmissionStart->add($interval);
+
+			$this->config->setAppValue("configreport", "telemetry.nextSubmission", $nextExecution->format(\DateTimeInterface::ATOM));
+		} else {
+			$nextExecution = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $nextExecution);
+		}
+
+		return $utcNow->getTimestamp() >= $nextExecution->getTimestamp();
+	}
+
+	public function storeNextExecution(\DateTimeImmutable $executionDateTime): void {
+		# set next execution to now + 24h
+		$this->config->setAppValue("configreport", "telemetry.nextSubmission", $executionDateTime->add(\DateInterval::createFromDateString('1 day'))->format(\DateTimeInterface::ATOM));
+	}
+
+	private function random(int $min, int $max): int {
+		if (self::$randomTest >=0) {
+			return self::$randomTest;
+		}
+		return random_int($min, $max);
+	}
+}

--- a/tests/unit/Telemetry/SchedulerTest.php
+++ b/tests/unit/Telemetry/SchedulerTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License, version 2,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\ConfigReport\Tests;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use OCA\ConfigReport\Telemetry\Scheduler;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class SchedulerTest extends TestCase {
+	/**
+	 * @var IConfig|MockObject
+	 */
+	private $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getSystemValue')->willReturnCallback(function ($key) {
+			if ($key === 'telemetry.startHour') {
+				return 6;
+			}
+			if ($key === 'telemetry.endHour') {
+				return 12;
+			}
+			throw new \RuntimeException(':bomb:');
+		});
+	}
+
+	public function testOutOfAllowedTimeframe(): void {
+		$utcNow = new DateTimeImmutable("now", new DateTimeZone('UTC'));
+		$tooLate = $utcNow->setTime(14, 0);
+		$tooEarly = $utcNow->setTime(4, 0);
+
+		$scheduler = new Scheduler($this->config);
+
+		self::assertFalse($scheduler->isDue($tooLate));
+		self::assertFalse($scheduler->isDue($tooEarly));
+	}
+
+	public function testFirstTime(): void {
+		# 09:00 is later than 08:03 which is the calculated next execution time
+		$due = new DateTimeImmutable("2024-07-02 09:00:00", new DateTimeZone('UTC'));
+
+		$nextExecution = 0;
+		$this->config->method('setAppValue')->willReturnCallback(function ($app, $key, $value) use (&$nextExecution) {
+			if ($app === 'configreport' && $key === 'telemetry.nextSubmission') {
+				$nextExecution = $value;
+				return;
+			}
+			throw new \RuntimeException(':bomb:');
+		});
+
+		$scheduler = new Scheduler($this->config);
+		Scheduler::$randomTest = 123;
+
+		self::assertTrue($scheduler->isDue($due));
+		self::assertEquals('2024-07-02T08:03:00+00:00', $nextExecution);
+	}
+
+	public function testNextExecution(): void {
+		# 09:00 is later than 08:03 which is the calculated next execution time
+		$due = new DateTimeImmutable("2024-07-02 09:00:00", new DateTimeZone('UTC'));
+
+		$this->config->method('setAppValue')->willReturnCallback(function ($app, $key, $value) {
+			throw new \RuntimeException(':bomb:');
+		});
+		$this->config->method('getAppValue')->willReturnCallback(function ($app, $key) use (&$nextExecution) {
+			if ($app === 'configreport' && $key === 'telemetry.nextSubmission') {
+				return '2024-07-02T08:03:00+00:00';
+			}
+			throw new \RuntimeException(':bomb:');
+		});
+
+		$scheduler = new Scheduler($this->config);
+		Scheduler::$randomTest = 123;
+
+		self::assertTrue($scheduler->isDue($due));
+	}
+}


### PR DESCRIPTION
…or business intelligence

# Note
## Explicit Release note required for community users
## Explicit documentation notice required for community users

@mmattel 


### Example Telemetry Content
```json
{
  "id": "ocrq6cgpjlqj",
  "report": {
    "basic": {
      "license key": "",
      "date": "Mon, 18 Mar 2024 11:25:09 +0000",
      "ownCloud version": "10.14.1.0",
      "ownCloud version string": "10.14.1 prealpha",
      "ownCloud edition": "Community",
      "server OS": "Linux",
      "server OS version": "Linux deepdiver 6.6.15-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.6.15-2 (2024-02-04) x86_64",
      "server SAPI": "cli",
      "webserver version": "???",
      "hostname": "???",
      "logged-in user": ""
    },
    "stats": {
      "users": {
        "Database": {
          "total_count": 1,
          "guest_count": 0,
          "seen": 0,
          "logged in (30 days)": 0
        }
      },
      "groups": {
        "OC\\Group\\Database": 1
      }
    },
    "config": {
      "telemetry.enabled": true,
      "passwordsalt": "***REMOVED SENSITIVE VALUE***",
      "secret": "***REMOVED SENSITIVE VALUE***",
      "trusted_domains": [
        "localhost"
      ],
      "datadirectory": "/home/deepdiver/Development/owncloud/core/data",
      "overwrite.cli.url": "http://localhost",
      "dbtype": "sqlite3",
      "version": "10.14.1.0",
      "allow_user_to_change_mail_address": "",
      "logtimezone": "UTC",
      "apps_paths": [
        {
          "path": "/home/deepdiver/Development/owncloud/core/apps",
          "url": "/apps",
          "writable": false
        },
        {
          "path": "/home/deepdiver/Development/owncloud/core/apps-external",
          "url": "/apps-external",
          "writable": true
        }
      ],
      "installed": true,
      "instanceid": "ocrq6cgpjlqj",
      "loglevel": 2,
      "maintenance": false
    },
    "phpinfo": []
  }
}