### PR TITLE
fix: strip stray .git dirs from release tarball; release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 
+## [0.4.1] - 2026-07-20
+
+### Fixed
+- Strip stray `.git` directories from `vendor/` in the release tarball. A
+  source/prefer-source composer install could leave bundled dependencies
+  (brick/math, ramsey/uuid) as full git clones; the volatile `.git/index`
+  broke the app's integrity signature during a server release build.
+
+
 ## [0.3.1] - 2025-05-12
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ $(bower_deps): $(BOWER)
 $(dist_dir)/$(app_name): $(composer_deps) $(bower_deps)
 	rm -Rf $@; mkdir -p $@
 	cp -R $(all_src) $@
+	# Strip any VCS metadata that a source/prefer-source composer install can
+	# leave inside vendor/ (e.g. brick/math, ramsey/uuid as git clones). A .git
+	# dir must never ship in a release: .git/index is volatile, so any later git
+	# touch rewrites it and breaks the app's integrity signature. Remove before
+	# signing so the manifest never references these files.
+	find $@ -name .git -prune -exec rm -Rf {} +
 
 ifdef CAN_SIGN
 	$(sign) --path="$(dist_dir)/$(app_name)"

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<description>Generate a Config Report</description>
 	<summary>Generate a Config Report</summary>
 	<author>owncloud.org</author>
-	<version>0.4.0</version>
+	<version>0.4.1</version>
 	<default_enable/>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
## Problem

The published **v0.4.0** release asset contains **94 `.git/` entries** — full git clones of bundled composer dependencies (`vendor/brick/math/.git`, `vendor/ramsey/uuid/.git`).

A `.git` directory must never ship in a release tarball. `.git/index` in particular is **volatile**: any git command that touches the nested repo rewrites it with a new hash. During a server release build (`ocrelease`, which integrity-signs the tree), that mutation breaks configreport's file-hash signature → `INVALID_HASH` at `occ integrity:check-app`.

## Root cause

`composer install` can materialize dependencies as git clones when run with `--prefer-source` (or from a dirty/cached vendor dir), leaving `.git` under `vendor/`. The `dist` target does `cp -R $(all_src) $@` (which includes `vendor/`) and tars it verbatim, so the `.git` dirs ship. A *clean* `composer install --no-dev` extracts from dist zips and produces no `.git`, but the release must be robust regardless of how `vendor/` got populated.

## Fix

Strip every nested `.git` from the staged dist tree **before signing** (so the signature manifest never references those files):

```make
find $@ -name .git -prune -exec rm -Rf {} +
```

Bumps the app version to **0.4.1** and adds a CHANGELOG entry.

## Verification

- With a deliberately dirty `composer install --no-dev --prefer-source` (3 `.git` dirs in `vendor/`), `make dist` now produces a tarball with **0 `.git` entries** and all real vendor/app files intact.
- Clean `composer install --no-dev` build also produces 0 `.git` and succeeds (the `find` is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)