### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 
+## [0.4.3] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
 ## [0.4.2] - 2026-07-22
 
 ### Changed
@@ -71,7 +76,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Decouple from core, switching to own release cycle
 - Drop PHP 5.6 support
 
-[Unreleased]: https://github.com/owncloud/configreport/compare/v0.4.2..master
+[Unreleased]: https://github.com/owncloud/configreport/compare/v0.4.3..master
+[0.4.3]: https://github.com/owncloud/configreport/compare/v0.4.2..v0.4.3
 [0.4.2]: https://github.com/owncloud/configreport/compare/v0.4.1..v0.4.2
 [0.4.1]: https://github.com/owncloud/configreport/compare/v0.3.1..v0.4.1
 [0.3.1]: https://github.com/owncloud/configreport/compare/v0.3.0..v0.3.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<description>Generate a Config Report</description>
 	<summary>Generate a Config Report</summary>
 	<author>owncloud.org</author>
-	<version>0.4.2</version>
+	<version>0.4.3</version>
 	<default_enable/>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
Patch-level version bump (0.4.2 -> 0.4.3) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.